### PR TITLE
Auto setting default language

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -130,12 +130,7 @@ module.exports = {
     locales: ['en', 'sv', 'fi', 'bi', 'da'],
     lazy: true,
     strategy: 'prefix',
-    defaultLocale: 'en',
-    rootRedirect: 'en/',
-    detectBrowserLanguage: false,
-    vueI18n: {
-      fallbackLocale: 'en'
-    }
+    detectBrowserLanguage: false
   },
 
   // axios: {

--- a/plugins/i18n.js
+++ b/plugins/i18n.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-export default function ({ store, app }) {
+export default function ({ store, app, redirect }) {
   axios.defaults.timeout = 60000
 
   if (!store.state.instance) {
@@ -47,8 +47,16 @@ export default function ({ store, app }) {
         }
       })
       app.i18n.setLocaleMessage(lang, translations)
-      console.log(`${lang} i18n strings loaded!`)
+
       store.commit('SET_LANGUAGES_LOADED', true)
+
+      // if no locale is define, use default from API
+      if (!app.i18n.locale && process.client) {
+        app.i18n.locale = store.state.instance.defaultLanguage || 'en'
+        redirect(app.localePath('index'))
+      }
     })
+  }).catch(function (error) {
+    console.log(error)
   })
 }

--- a/plugins/i18n.js
+++ b/plugins/i18n.js
@@ -50,7 +50,7 @@ export default function ({ store, app, redirect }) {
 
       store.commit('SET_LANGUAGES_LOADED', true)
 
-      // if no locale is define, use default from API
+      // if no locale is defined, use default from API
       if (!app.i18n.locale && process.client) {
         app.i18n.locale = store.state.instance.defaultLanguage || 'en'
         redirect(app.localePath('index'))


### PR DESCRIPTION
On app initialization, in the i18n plugin, once we get instance data from the API, see if user has specified a locale (entered /en /sv etc). If not, set the default language from the API and redirect user to the locale path (/en /sv etc).