### PR TITLE
Develop on localhost

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   ],
   // add your custom rules here
   rules: {
-    'nuxt/no-cjs-in-config': 'off'
+    'nuxt/no-cjs-in-config': 'off',
+    'no-console': 'off'
   }
 }

--- a/README.md
+++ b/README.md
@@ -8,11 +8,18 @@ SIGNATURE=4567
 API_ENDPOINT=https://my_api.com/graphql
 AUTH0_DOMAIN=domain.auth0.com
 AUTH0_CLIENT_ID=abc123
+DEFAULT_INSTANCE_ID=your-instance-674bb737a19d3046
 ```
 
+## Use localhost:300 for development
+
+If you've already created an instance with the Dashboard application, you can set it as your default instance. This allows you to work on the website without any changes to your local /etc/hosts file. You will only be able to navigate the default instance.
+
 ## Set up local hosts DNS
-The app relies on the subdomain to establish the instance ID. So you have to create a fake local hostname for this.
-Edit your local hosts file `/etc/hosts` on Mac/Linux as root (Windows most likey at `c:\Windows\System32\Drivers\etc\hosts` but please Google it for your OS) and add the following records:
+
+If you would like to be able to naviagate all instances locally, you will need to configure your /etc/hosts file accomodate.
+
+Edit your local hosts file `/etc/hosts` on Mac/Linux as root (Windows most likey at `c:\Windows\System32\Drivers\etc\hosts` but please Google it for your OS) and add the following records, sbstituting your own instance IDs:
 
 ``` bash
 127.0.0.1 www.cosopho.com

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -10,8 +10,8 @@ module.exports = {
     apiEndpoint: process.env.API_ENDPOINT,
     signature: process.env.SIGNATURE,
     cloudinaryApi: process.env.CLOUDINARY_API,
-    fathom: process.env.FATHOM
-
+    fathom: process.env.FATHOM,
+    defaultInstanceID: process.env.DEFAULT_INSTANCE_ID
   },
 
   head: {

--- a/plugins/start.js
+++ b/plugins/start.js
@@ -20,12 +20,12 @@ export default async function ({ store, app, req, redirect, error }) {
     subdomain = 'the-finnish--d7330c10c367d4fd'
   } else if ((req.headers.host).includes('nordiskamuseet.collectingsocialphoto.')) {
     subdomain = 'nordic-museu-76ba77f9ebd5d275'
-  } else if ((req.headers.host).includes('cosopho.collectingsocialphoto.')) {
-    subdomain = 'connect-to-c-5f0ff3a2fc4cd1fe'
   } else if ((req.headers.host).includes('vasternorrland.collectingsocialphoto.')) {
     subdomain = 'stiftelsen-l-ea94dfe2c6210320'
+  } else {
+    // TODO: add a default instance name in .env
+    subdomain = 'connect-to-c-5f0ff3a2fc4cd1fe'
   }
-
 
   if (subdomain === 'www' && !req.url.includes('/about-cosopho')) {
     redirect('/en/home')
@@ -82,12 +82,12 @@ export default async function ({ store, app, req, redirect, error }) {
     response.data.data.instance.languages = _.union(languages)
 
     if (process.env.NODE_ENV !== 'production') {
-      currentHostname = `http://${response.data.data.instance.id}.cosopho.com:3000`
+      currentHostname = 'http' + currentHostname.substr(5)
     }
 
     store.commit('SET_INSTANCE', response.data.data.instance)
     store.commit('SET_HOSTNAME', currentHostname)
   } else {
-    console.log("NO INSTANCE")
+    console.log('NO INSTANCE')
   }
 }

--- a/plugins/start.js
+++ b/plugins/start.js
@@ -23,8 +23,7 @@ export default async function ({ store, app, req, redirect, error }) {
   } else if ((req.headers.host).includes('vasternorrland.collectingsocialphoto.')) {
     subdomain = 'stiftelsen-l-ea94dfe2c6210320'
   } else {
-    // TODO: add a default instance name in .env
-    subdomain = 'connect-to-c-5f0ff3a2fc4cd1fe'
+    subdomain = process.env.defaultInstanceID
   }
 
   if (subdomain === 'www' && !req.url.includes('/about-cosopho')) {
@@ -32,7 +31,7 @@ export default async function ({ store, app, req, redirect, error }) {
   }
 
   if (subdomain === 'www') {
-    subdomain = 'connect-to-c-5f0ff3a2fc4cd1fe'
+    subdomain = process.env.defaultInstanceID
   }
 
   const payload = {


### PR DESCRIPTION
Allows a developer to set up on localhost:3000 using the default instance defined in the .env file.

﻿- uses connect-to-collect as default instance
- added default instance id to env
- updated README
